### PR TITLE
Handle empty compare view search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -12035,6 +12035,10 @@ elif page == "比較ビュー":
         snapshot = snapshot[
             snapshot["display_name"].str.contains(search, case=False, na=False)
         ]
+
+    if snapshot.empty:
+        st.info("該当するSKUがありません。検索条件を見直してください。")
+        st.stop()
     # ---- 操作バー＋グラフ密着カード ----
 
     band_params_initial = params.get("band_params", {})


### PR DESCRIPTION
## Summary
- show an informational message when the compare view search returns no SKUs
- stop further rendering to avoid displaying an empty chart card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8007dfa108323ac8bbce0fbc8831c