### PR TITLE
Handle missing product_name column in ranking snapshot

### DIFF
--- a/app.py
+++ b/app.py
@@ -11535,7 +11535,12 @@ elif page == "ランキング":
         snapshot = snapshot.merge(hierarchy_df, on="product_code", how="left")
     snapshot["department"] = snapshot.get("department", "その他").fillna("その他")
     snapshot["category"] = snapshot.get("category", "未分類").fillna("未分類")
-    snapshot["product_name"] = snapshot["product_name"].fillna(snapshot["product_code"])
+    if "product_name" not in snapshot.columns:
+        snapshot["product_name"] = snapshot["product_code"]
+    else:
+        snapshot["product_name"] = snapshot["product_name"].fillna(
+            snapshot["product_code"]
+        )
     snapshot["gross_est"] = (
         snapshot["year_sum"] * gross_ratio if gross_ratio > 0 else np.nan
     )


### PR DESCRIPTION
## Summary
- guard against missing `product_name` in ranking snapshot data
- default the product name to the product code when the column is absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87cee3ca48323b65f6c67aa342fc5