### PR TITLE
Adjust chart body slider spacing

### DIFF
--- a/app.py
+++ b/app.py
@@ -12074,6 +12074,8 @@ elif page == "比較ビュー":
   .chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:var(--ink,var(--primary,#0B1F3B)); font-weight:600; }
   .chart-toolbar .stSlider label { color:var(--ink,var(--primary,#0B1F3B)); }
   .chart-body { padding:var(--space-1) var(--space-2) var(--space-2); }
+  .chart-body .stSlider { margin-top:0 !important; margin-bottom:0 !important; }
+  .chart-body .stCaption { margin-top:var(--space-0, 0) !important; margin-bottom:0 !important; }
   </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- reduce the spacing around chart-body sliders so the line chart sits closer to the controls
- trim caption margins within chart-body sections to keep annotations tight to the chart

## Testing
- streamlit run app.py

------
https://chatgpt.com/codex/tasks/task_e_68d96d8dcefc8323b3e4f0a6614115e0