### PR TITLE
Fix duplicate index error in SKU correlation pivot

### DIFF
--- a/app.py
+++ b/app.py
@@ -13112,8 +13112,11 @@ elif page == "相関分析":
                         months_window = months_all[start_idx : end_idx + 1]
                         df_window = df_year[df_year["month"].isin(months_window)]
                         pivot = (
-                            df_window.pivot(
-                                index="month", columns="product_code", values=sku_metric
+                            df_window.pivot_table(
+                                index="month",
+                                columns="product_code",
+                                values=sku_metric,
+                                aggfunc="first",
                             ).sort_index()
                         )
                         pivot = pivot.dropna(how="all")


### PR DESCRIPTION
## Summary
- replace the SKU correlation pivot with a pivot_table that tolerates duplicate month/product combinations by taking the first value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9e888830c83238c47bf9663649048