### PR TITLE
Fix anomaly summary score counts

### DIFF
--- a/ai_features.py
+++ b/ai_features.py
@@ -195,9 +195,12 @@ def generate_anomaly_brief(anomalies: pd.DataFrame, top_n: int = 5) -> str:
         )
         return pipe(prompt, max_new_tokens=150)[0]["generated_text"].strip()
 
+    scores = pd.to_numeric(
+        anomalies.get("score", pd.Series(dtype=float)), errors="coerce"
+    )
     total = len(anomalies)
-    pos = int((anomalies.get("score", pd.Series(dtype=float)) > 0).sum())
-    neg = total - pos
+    pos = int((scores > 0).sum())
+    neg = int((scores < 0).sum())
     parts = [f"異常値{total}件（上振れ{pos}件・下振れ{neg}件）。"]
     highlights = []
     for _, row in subset.iterrows():


### PR DESCRIPTION
## Summary
- ensure anomaly scores are converted to numeric before calculating aggregates
- count positive and negative anomalies separately so neutral scores are not misclassified

## Testing
- pytest tests/test_ai_features.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9f14d06e48323a2309b93fa2562f1