### PR TITLE
Fix SKU detail multiselect remove icon

### DIFF
--- a/app.py
+++ b/app.py
@@ -1282,6 +1282,12 @@ select{
   pointer-events:none;
   z-index:1;
 }
+[data-baseweb="select"] [data-baseweb="tag"] svg{
+  pointer-events:auto;
+}
+[data-baseweb="select"] [data-baseweb="tag"]{
+  cursor:pointer;
+}
 [data-baseweb="input"] [aria-hidden="true"],
 [data-baseweb="select"] [aria-hidden="true"]{
   pointer-events:none;


### PR DESCRIPTION
## Summary
- re-enable pointer interactions on SKU detail multi-select chips so the remove button works again
- show a pointer cursor over selected chips to clarify they are interactive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9f215f29c8323a7ff631e1e554ba9